### PR TITLE
Fix dependency loop with EcsIter

### DIFF
--- a/src/c.zig
+++ b/src/c.zig
@@ -256,9 +256,9 @@ pub const EcsIter = extern struct {
     flags: EcsFlags32,
     interrupted_by: EcsEntity,
     priv: EcsIterPrivate,
-    next: ?EcsIterNextAction,
-    callback: ?EcsIterAction,
-    fini: ?EcsIterFiniAction,
+    next: if (builtin.zig_backend == .stage1) ?fn ([*c]EcsIter) callconv(.C) bool else ?*const fn ([*c]EcsIter) callconv(.C) bool,
+    callback: if (builtin.zig_backend == .stage1) ?fn (*EcsIter) callconv(.C) void else ?*const fn (*EcsIter) callconv(.C) void,
+    fini: if (builtin.zig_backend == .stage1) ?fn ([*c]EcsIter) callconv(.C) void else ?*const fn ([*c]EcsIter) callconv(.C) void,
     chain_it: [*c]EcsIter,
 };
 


### PR DESCRIPTION
Stage2 is unable to reason about the "dependency loop" of `EcsIterAction` referencing `EcsIter` which references `EcsIterNextAction` and so on. This PR fixes the issue by hardcoding the function type in `EcsIter` instead of using the type aliases.

```zig
deps/zig-flecs/src/c.zig:219:5: error: dependency loop detected
pub const EcsIterAction = if (builtin.zig_backend == .stage1) fn (*EcsIter) callconv(.C) void else *const fn (*EcsIter) callconv(.C) void;
~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    EcsIter: deps/zig-flecs/src/c.zig:222:28
    EcsIterNextAction: deps/zig-flecs/src/c.zig:218:122
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```