### PR TITLE
Support 0.11.x build API and unify tag components

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -44,11 +44,13 @@ pub fn build(b: *Build) anyerror!void {
             break :blk exe;
         };
 
+        exe.setOutputDir("zig-cache/bin");
         link(exe, target);
 
         const run_cmd = exe.run();
         const exe_step = b.step(name, b.fmt("run {s}.zig", .{ name }));
         exe_step.dependOn(&run_cmd.step);
+        examples_step.dependOn(&exe.step);
     }
 
     // only mac and linux get the update_flecs command

--- a/build.zig
+++ b/build.zig
@@ -1,29 +1,53 @@
 const builtin = @import("builtin");
 const std = @import("std");
 
+const new_build_system = @hasDecl(std, "Build");
+const Build = if (new_build_system) std.Build else std.build.Builder;
+const CompileStep = if (new_build_system) Build.CompileStep else std.build.LibExeObjStep;
+const FileSource = if (new_build_system) Build.FileSource else std.build.FileSource;
+
 const current_version = "3.1.1";
 
-pub fn build(b: *std.build.Builder) anyerror!void {
+pub fn build(b: *Build) anyerror!void {
     const target = b.standardTargetOptions(.{});
 
-    const examples = getAllExamples(b, "examples");
+    const examples = getAllExamples(b, b.pathFromRoot("examples"));
 
     const examples_step = b.step("all_examples", "build all examples");
     b.default_step.dependOn(examples_step);
+
+    if (new_build_system) {
+        b.addModule(.{
+            .name = "flecs",
+            .source_file = FileSource.relative("src/flecs.zig"),
+        });
+    }
 
     for (examples) |example| {
         const name = example[0];
         const source = example[1];
 
-        var exe = b.addExecutable(name, source);
-        exe.setTarget(target);
-        exe.setOutputDir("zig-cache/bin");
+        const exe = if (new_build_system) blk: {
+            const exe = b.addExecutable(.{
+                .name = name,
+                .root_source_file = .{ .path = source },
+                .target = target,
+            });
+            exe.addModule("flecs", b.modules.get("flecs").?);
+
+            break :blk exe;
+        } else blk: {
+            const exe = b.addExecutable(name, source);
+            exe.setTarget(target);
+            exe.addPackage(pkg);
+
+            break :blk exe;
+        };
 
         link(exe, target);
-        exe.addPackage(pkg);
 
         const run_cmd = exe.run();
-        const exe_step = b.step(name, b.fmt("run {s}.zig", .{name}));
+        const exe_step = b.step(name, b.fmt("run {s}.zig", .{ name }));
         exe_step.dependOn(&run_cmd.step);
     }
 
@@ -35,7 +59,7 @@ pub fn build(b: *std.build.Builder) anyerror!void {
     }
 }
 
-fn getAllExamples(b: *std.build.Builder, root_directory: []const u8) [][2][]const u8 {
+fn getAllExamples(b: *Build, root_directory: []const u8) [][2][]const u8 {
     var list = std.ArrayList([2][]const u8).init(b.allocator);
 
     const recursor = struct {
@@ -67,10 +91,20 @@ fn getAllExamples(b: *std.build.Builder, root_directory: []const u8) [][2][]cons
 
 pub const pkg = std.build.Pkg{
     .name = "flecs",
-    .source = .{ .path = thisDir() ++ "/src/flecs.zig" },
+    .source = .{
+        .path = thisDir() ++ "/src/flecs.zig",
+    },
 };
 
-pub fn link(exe: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
+pub fn module(b: *std.Build) *std.Build.Module {
+    return b.createModule(.{
+        .source_file = .{
+            .path = thisDir() ++ "/src/flecs.zig",
+        },
+    });
+}
+
+pub fn link(exe: *CompileStep, target: std.zig.CrossTarget) void {
     exe.linkLibC();
     exe.addIncludePath(thisDir() ++ "/src/c");
 

--- a/src/flecs.zig
+++ b/src/flecs.zig
@@ -87,21 +87,18 @@ pub fn ecs_component(world: *c.EcsWorld, comptime T: type) void {
     const entity_desc = std.mem.zeroInit(c.EcsEntityDesc, .{
         .name = @typeName(T),
         .id = handle.*,
-        .use_low_id = @sizeOf(T) > 0,
+        .use_low_id = true,
     });
 
-    if (@sizeOf(T) == 0) {
-        handle.* = c.ecs_entity_init(world, &entity_desc);
-    } else {
-        const component_desc = std.mem.zeroInit(c.EcsComponentDesc, .{
-            .entity = c.ecs_entity_init(world, &entity_desc),
-            .type = .{
-                .alignment = @alignOf(T),
-                .size = @sizeOf(T),
-            },
-        });
-        handle.* = c.ecs_component_init(world, &component_desc);
-    }
+    const component_desc = std.mem.zeroInit(c.EcsComponentDesc, .{
+        .entity = c.ecs_entity_init(world, &entity_desc),
+        .type = .{
+            .alignment = @alignOf(T),
+            .size = @sizeOf(T),
+        },
+    });
+
+    handle.* = c.ecs_component_init(world, &component_desc);
 }
 
 /// Registers a new system with the world run during the given phase.


### PR DESCRIPTION
`build.zig` changes:

 - `build.zig` now detects whether the new build system is available and handles it appropriately: the new build system has breaking API changes; most notably in the removal of `std.build.Pkg` and breaking changes to how executable artifacts are created. For backwards compatibility with projects pinned to an old Zig version, the `pkg` field is still provided (lazy evaluation means that in new projects it won't cause any errors).

 - The `flecs` module *should* be exposed when using the package due to the use of `b.addModule`, but without exposing the functionality provided by `link` it's probably not possible to use `zig-flecs` with the package manager yet. Therefore, end users should probably still vendor or submodule this project and use the `module()` function provided in the updated `build.zig` file.

 - The build process works in both 0.11.x and 0.10.1 and the example executes successfully.

`ecs_component` changes:

 - Following a discussion with Sander in the Flecs discord, the special casing for zero-sized types in `ecs_component` has been removed: the Flecs C++ binding lacks this special-casing (zero-sized types are registered as ordinary components), and Sander thinks that the `ECS_TAG` macro in the C API should probably set the `use_low_id` option as well.