### PR TITLE
Check argument types more consistently

### DIFF
--- a/examples/entities/entities_basics.zig
+++ b/examples/entities/entities_basics.zig
@@ -128,7 +128,7 @@ pub fn main() !void {
     }
 
     flecs.ecs_set_pair(world, alice, Likes{ .amount = 10 }, bob);
-    flecs.ecs_set_pair_second(world, alice, Likes, &Apples{ .count = 4 });
+    flecs.ecs_set_pair(world, alice, Likes{ .amount = 4 }, Apples);
 
     if (flecs.ecs_get_pair(world, alice, Likes, bob)) |b| {
         std.log.debug("How much does Alice like bob? {d}", .{b.amount});


### PR DESCRIPTION
This commit introduces a `validComponentType(T)` function that verifies that a component type is a container type like `struct`, `enum`, or `union` and changes all `std.debug.assert` calls to `comptime` so that these errors can be caught immediately.

Previously the checks were inconsistent depending on the function: sometimes only structs were accepted, sometimes enums were accepted too, and unions were never accepted in the first place!

Now, `IdHandle(T)` used by `ecs_id(T)` and `ecs_id_handle(T)` is responsible for doing these argument type checks for the most part.

Additional changes:

 - Usage of `@typeInfo(T)` has been pruned where possible as `@typeInfo(T) == .Type` is equivalent to `T == type` and the type info isn't usually referenced elsewhere in the function.

 - Previously `ecs_set_pair_second` had a check that logged a warning if the first type in the pair was a component with data, but in actuality it did nothing at all because it always checked the size of the `type` type rather than the actual component. Now the check is implemented properly and causes a compile error rather than logging a warning since types with incompatible layouts must not be assigned to each other.

 - Due to the change with `ecs_set_pair_second`, a bug in the `entities_basics` example was uncovered and fixed: Alice apparently liked 4 apples, but since the `Likes` component is associated with data, `ecs_set_pair_second` was actually associating data with the first component. This bug was probably uncaught because the warning message was never printed in the past due to the condition never being triggered.